### PR TITLE
use hcv as storage backend for sg dev_team

### DIFF
--- a/konnect/sg.nix
+++ b/konnect/sg.nix
@@ -29,7 +29,7 @@ in
             "chocolate"
           ];
           generate_token = true;
-          storage_backend = [ "local" ];
+          storage_backend = [ "hcv" ];
         };
       };
     };


### PR DESCRIPTION
Store the generated system token in Hashicorp vault instead of local.