### PR TITLE
remove prod cp to us region

### DIFF
--- a/konnect/us.nix
+++ b/konnect/us.nix
@@ -29,20 +29,6 @@
             team = "platform";
           };
         };
-        prod = {
-          name = "production";
-          description = "production control plane";
-          custom_plugins = [ "path-prefix" ];
-          create_certificate = true;
-          system_account = {
-            enable = true;
-            generate_token = true;
-          };
-          labels = {
-            environment = "prod";
-            team = "platform";
-          };
-        };
       };
     };
   };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed production control plane configuration from the US region. The region now contains only development and staging environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->